### PR TITLE
Prepare install script: npm run pluginInstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ JavaScript Runner for [Gauge](http://www.getgauge.io).
 $ git clone git@github.com:renjithgr/gauge-js.git --recursive
 ```
 
-**Copy:** Copy all contents of the `gauge-js` dir to the following directories:
+**Install plugin:**
 
-- Windows: `%APPDATA%\.gauge\plugins\js\0.0.1\`
-- MacOS: `~/.gauge/plugins/js/0.0.1/`
-- Linux: `~/.gauge/plugins/js/0.0.1/`
+```sh
+$ cd gauge-js
+$ npm install
+$ npm run installPlugin
+```
 
 **Initialize:** To initialize a project with gauge-js, in an empty directory run:
 

--- a/copy2PluginDir.sh
+++ b/copy2PluginDir.sh
@@ -1,1 +1,0 @@
-rm -rf ~/.gauge/plugins/js/0.0.1/* && cp -rf ./* ~/.gauge/plugins/js/0.0.1/

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "gauge-js",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "JavaScript runner for Gauge",
   "main": "index.js",
   "scripts": {
     "check-style": "./node_modules/.bin/jscs *.js src/ test/",
     "lint": "./node_modules/.bin/jshint *.js src/ test/",
-    "test": "./node_modules/.bin/mocha --recursive"
+    "test": "./node_modules/.bin/mocha --recursive",
+    "installPlugin": "node ./scripts/install.js"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.0",
+    "fs-extra": "^0.26.4",
     "jscs": "^2.8.0",
     "jshint": "^2.8.0",
     "mocha": "^2.3.3",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,0 +1,44 @@
+var fs = require("fs-extra"),
+    path = require("path"),
+    CWD = process.cwd();
+
+var localPath = function (relativePath) {
+  return relativePath ? path.resolve(CWD, relativePath) : path.resolve(CWD);
+};
+
+var plugin = require(localPath("./js.json"));
+
+var homeDir = process.env[(process.platform == "win32") ? "USERPROFILE" : "HOME"];
+
+var pluginInstallDir = path.resolve(homeDir, ".gauge", "plugins", plugin.id, plugin.version);
+
+var cleanInstallDir = function () {
+  try {
+    fs.removeSync(pluginInstallDir);
+  } catch (err) {
+    console.error("Error removing plugin installation directory: %s", err.message);
+  }
+};
+
+var createInstallDir = function () {
+  try {
+    fs.ensureDirSync(pluginInstallDir);
+  } catch (err) {
+    console.error("Error creating plugin installation directory: %s", err.message);
+  }
+};
+
+var copyPluginFiles = function () {
+  cleanInstallDir();
+  createInstallDir();
+
+  try {
+    fs.copySync(localPath(), pluginInstallDir);
+  } catch (err) {
+    console.error("Failed to install plugin: %s", err.message);
+  }
+
+  console.log("Installed gauge-%s v%s", plugin.id, plugin.version);
+};
+
+copyPluginFiles();

--- a/test/package-test.js
+++ b/test/package-test.js
@@ -1,0 +1,24 @@
+var assert = require("chai").assert;
+
+describe("Package", function () {
+
+  var packageJSON = require("../package.json"),
+      jsJSON = require("../js.json");
+
+  describe("version", function () {
+
+    it("should be same in package.json and js.json", function () {
+      assert.equal(packageJSON.version, jsJSON.version);
+    });
+
+  });
+
+  describe("name", function () {
+
+    it("should be gauge-<id> where <id> equals <id> in js.json", function () {
+      assert.equal(packageJSON.name, "gauge-" + jsJSON.id);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This script takes data from `./js.json` and installs the plugin in appropriate folder.

This behaviour needs to be modified once `gauge` has custom install location as requested in getgauge/gauge#243.