### PR TITLE
Add support for execution hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "JavaScript"
   ],
   "author": "Renjith G R",
-  "license": "GPLv3",
+  "license": "GPL-3.0",
   "bugs": {
     "url": "https://github.com/renjithgr/gauge-js/issues"
   },

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "JavaScript runner for Gauge",
   "main": "index.js",
   "scripts": {
-    "check-style": "./node_modules/.bin/jscs *.js src/ test/",
-    "lint": "./node_modules/.bin/jshint *.js src/ test/",
+    "check-style": "./node_modules/.bin/jscs *.js src/ skel/ test/",
+    "lint": "./node_modules/.bin/jshint *.js src/ skel/ test/",
     "test": "npm run check-style && npm run lint && ./node_modules/.bin/mocha --recursive",
     "installPlugin": "node ./scripts/install.js"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "check-style": "./node_modules/.bin/jscs *.js src/ test/",
     "lint": "./node_modules/.bin/jshint *.js src/ test/",
-    "test": "./node_modules/.bin/mocha --recursive",
+    "test": "npm run check-style && npm run lint && ./node_modules/.bin/mocha --recursive",
     "installPlugin": "node ./scripts/install.js"
   },
   "repository": {

--- a/skel/step_implementation.js
+++ b/skel/step_implementation.js
@@ -1,11 +1,42 @@
-gauge('A context step which gets executed before every scenario', function() {
-    console.log('A context step which gets executed before every scenario');
+/* globals gauge, beforeScenario */
+
+"use strict";
+
+var assert = require("assert");
+
+var vowels = ["a", "e", "i", "o", "u"];
+
+var numberOfVowels = function (word) {
+  var vowelArr = word.split("").filter(function (elem) { return vowels.indexOf(elem) > -1; });
+  return vowelArr.length;
+};
+
+// --------------------------
+// Gauge step implementations
+// --------------------------
+
+gauge("Vowels in English language are <vowels>.", function(vowelsGiven) {
+  assert.equal(vowelsGiven, vowels.join(""));
 });
 
-gauge('Say <greeting> to <user>', function(greeting, user) {
-    console.log('Say ' + greeting + ' to ' + user);
+gauge("The word <word> has <number> vowels.", function(word, number) {
+  assert.equal(number, numberOfVowels(word));
 });
 
-gauge('Step that takes a table <table>', function(table) {
-    console.log('Step that takes a ' + table);
+gauge("Almost all words have vowels <table>", function(table) {
+  table.rows.forEach(function (row) {
+    assert.equal(numberOfVowels(row.cells[0]), parseInt(row.cells[1]));
+  });
 });
+
+// ---------------
+// Execution Hooks
+// ---------------
+
+beforeScenario(function () {
+  assert.equal(vowels.join(""), "aeiou");
+});
+
+beforeScenario(function () {
+  assert.equal(vowels[0], "a");
+}, { tags: [ "single word" ]});

--- a/src/gauge-global.js
+++ b/src/gauge-global.js
@@ -1,11 +1,20 @@
-var StepRegistry = require("./step-registry");
+var StepRegistry = require("./step-registry"),
+    HookRegistry = require("./hook-registry"),
+    stepParser = require("./step-parser");
 
-global.stepParser = require("./step-parser");
+global.stepParser = stepParser;
 global.stepRegistry = new StepRegistry();
+global.hookRegistry = new HookRegistry();
 
 global.gauge = function(stepName, stepFunction) {
   var generalisedName = global.stepParser.generalise(stepName);
   global.stepRegistry.add(generalisedName, stepFunction);
 };
+
+global.hookRegistry.types.forEach(function (type) {
+  global[type] = function (fn) {
+    global.hookRegistry.add(type, fn);
+  };
+});
 
 module.exports = {};

--- a/src/gauge-global.js
+++ b/src/gauge-global.js
@@ -12,8 +12,8 @@ global.gauge = function(stepName, stepFunction) {
 };
 
 global.hookRegistry.types.forEach(function (type) {
-  global[type] = function (fn) {
-    global.hookRegistry.add(type, fn);
+  global[type] = function (fn, options) {
+    global.hookRegistry.add(type, fn, options);
   };
 });
 

--- a/src/gauge.js
+++ b/src/gauge.js
@@ -8,7 +8,6 @@ var GAUGE_PROJECT_ROOT = process.env.GAUGE_PROJECT_ROOT;
 
 function run() {
   impl_loader.load(GAUGE_PROJECT_ROOT);
-  console.log("Initializing Connection");
 
   var gaugeInternalConnection = new Connection("localhost", GAUGE_INTERNAL_PORT);
   gaugeInternalConnection.run();

--- a/src/hook-registry.js
+++ b/src/hook-registry.js
@@ -1,0 +1,38 @@
+var HookRegistry = function () {
+  this.registry = {};
+};
+
+var InvalidHookException = function (message) {
+  this.message = message;
+  this.name = "InvalidHookException";
+};
+
+HookRegistry.prototype.types = [
+  "beforeSuite",
+  "afterSuite",
+  "beforeSpec",
+  "afterSpec",
+  "beforeScenario",
+  "afterScenario",
+  "beforeStep",
+  "afterStep"
+];
+
+HookRegistry.prototype.add = function (hookName, hookFn) {
+  if (!hookName) {
+    throw new InvalidHookException("Need a hook name");
+  }
+
+  if (this.types.indexOf(hookName) < 0) {
+    throw new InvalidHookException("Invalid hook name: " + hookName);
+  }
+
+  this.registry[hookName] = this.registry[hookName] || [];
+  this.registry[hookName].push(hookFn);
+};
+
+HookRegistry.prototype.get = function (hookName) {
+  return this.registry[hookName] ? this.registry[hookName] : this.registry;
+};
+
+module.exports = HookRegistry;

--- a/src/hook-registry.js
+++ b/src/hook-registry.js
@@ -28,7 +28,7 @@ HookRegistry.prototype.add = function (hookName, hookFn, options) {
   }
 
   this.registry[hookName] = this.registry[hookName] || [];
-  this.registry[hookName].push({'fn': hookFn, 'options': options});
+  this.registry[hookName].push({"fn": hookFn, "options": options});
 };
 
 HookRegistry.prototype.get = function (hookName) {

--- a/src/hook-registry.js
+++ b/src/hook-registry.js
@@ -18,7 +18,7 @@ HookRegistry.prototype.types = [
   "afterStep"
 ];
 
-HookRegistry.prototype.add = function (hookName, hookFn) {
+HookRegistry.prototype.add = function (hookName, hookFn, options) {
   if (!hookName) {
     throw new InvalidHookException("Need a hook name");
   }
@@ -28,7 +28,7 @@ HookRegistry.prototype.add = function (hookName, hookFn) {
   }
 
   this.registry[hookName] = this.registry[hookName] || [];
-  this.registry[hookName].push(hookFn);
+  this.registry[hookName].push({'fn': hookFn, 'options': options});
 };
 
 HookRegistry.prototype.get = function (hookName) {

--- a/src/processor/ExecuteHookProcessor.js
+++ b/src/processor/ExecuteHookProcessor.js
@@ -7,14 +7,40 @@ function executionResponse(isFailed, executionTime, messageId, e) {
   return ResponseFactory.getExecutionStatusResponseMessage (messageId, isFailed, executionTime, e);
 }
 
+/**
+ * Source: http://stackoverflow.com/a/26034767/575242
+ */
+var hasIntersection = function (arr1, arr2) {
+  var intArr = arr1.filter(function (elem) { return arr2.indexOf(elem) > -1; });
+  return intArr.length;
+};
+
+function filterHooks(hooks, tags) {
+  return hooks.filter(function(hook) {
+    var hookTags = (hook.options && hook.options.tags) ? hook.options.tags : [];
+    var hookOperator = (hook.options && hook.options.operator) ? hook.options.operator : "AND";
+    if (!hookTags.length) {
+      return true;
+    }
+    var matched = hasIntersection(tags, hookTags);
+    switch(hookOperator){
+    case "AND":
+      return matched === hookTags.length;
+    case "OR":
+      return matched > 0;
+    }
+    return false;
+  });
+}
+
 var ExecuteHook = function(request, hookLevel, currentExecutionInfo) {
   var deferred = Q.defer(),
       timestamp = Date.now(),
       tags = [];
 
   if (currentExecutionInfo) {
-    specTags = currentExecutionInfo.currentSpec ? currentExecutionInfo.currentSpec.tags : [];
-    sceanarioTags = currentExecutionInfo.currentScenario ? currentExecutionInfo.currentScenario.tags : [];
+    var specTags = currentExecutionInfo.currentSpec ? currentExecutionInfo.currentSpec.tags : [];
+    var sceanarioTags = currentExecutionInfo.currentScenario ? currentExecutionInfo.currentScenario.tags : [];
     tags = specTags.concat(sceanarioTags);
   }
 
@@ -34,31 +60,5 @@ var ExecuteHook = function(request, hookLevel, currentExecutionInfo) {
 
   return deferred.promise;
 };
-
-/**
- * Source: http://stackoverflow.com/a/26034767/575242
- */
-var hasIntersection = function (arr1, arr2) {
-  var intArr = arr1.filter(function (elem) { return arr2.indexOf(elem) > -1 });
-  return intArr.length;
-};
-
-function filterHooks(hooks, tags) {
-  return hooks.filter(function(hook) {
-      var hookTags = (hook.options && hook.options.tags) ? hook.options.tags : [];
-      var hookOperator = (hook.options && hook.options.operator) ? hook.options.operator : "AND";
-      if (!hookTags.length) {
-        return true;
-      }
-      var matched = hasIntersection(tags, hookTags);
-      switch(hookOperator){
-        case "AND":
-          return matched === hookTags.length;
-        case "OR":
-          return matched > 0;
-      }
-      return false;
-  });
-}
 
 module.exports = ExecuteHook;

--- a/src/processor/ExecuteHookProcessor.js
+++ b/src/processor/ExecuteHookProcessor.js
@@ -9,12 +9,21 @@ function executionResponse(isFailed, executionTime, messageId, e) {
 
 var ExecuteHook = function(request, hookLevel, currentExecutionInfo) {
   var deferred = Q.defer(),
-      timestamp = Date.now();
+      timestamp = Date.now(),
+      tags = [];
+
+  if (currentExecutionInfo) {
+    specTags = currentExecutionInfo.currentSpec ? currentExecutionInfo.currentSpec.tags : [];
+    sceanarioTags = currentExecutionInfo.currentScenario ? currentExecutionInfo.currentScenario.tags : [];
+    tags = specTags.concat(sceanarioTags);
+  }
 
   var hooks = hookRegistry.get(hookLevel);
-  for (var i = 0; i < hooks.length; i++) {
+  var filteredHooks = hooks.length ? filterHooks(hooks, tags) : [];
+
+  for (var i = 0; i < filteredHooks.length; i++) {
     try {
-      hooks[i].apply({}, [currentExecutionInfo, hookLevel]);
+      filteredHooks[i].fn.apply({}, [currentExecutionInfo, hookLevel]);
     } catch (e) {
       deferred.reject(executionResponse(true, (Date.now() - timestamp), request.messageId, e));
       return deferred.promise;
@@ -25,5 +34,31 @@ var ExecuteHook = function(request, hookLevel, currentExecutionInfo) {
 
   return deferred.promise;
 };
+
+/**
+ * Source: http://stackoverflow.com/a/26034767/575242
+ */
+var hasIntersection = function (arr1, arr2) {
+  var intArr = arr1.filter(function (elem) { return arr2.indexOf(elem) > -1 });
+  return intArr.length;
+};
+
+function filterHooks(hooks, tags) {
+  return hooks.filter(function(hook) {
+      var hookTags = (hook.options && hook.options.tags) ? hook.options.tags : [];
+      var hookOperator = (hook.options && hook.options.operator) ? hook.options.operator : "AND";
+      if (!hookTags.length) {
+        return true;
+      }
+      var matched = hasIntersection(tags, hookTags);
+      switch(hookOperator){
+        case "AND":
+          return matched === hookTags.length;
+        case "OR":
+          return matched > 0;
+      }
+      return false;
+  });
+}
 
 module.exports = ExecuteHook;

--- a/src/processor/ExecuteHookProcessor.js
+++ b/src/processor/ExecuteHookProcessor.js
@@ -1,0 +1,29 @@
+/* globals hookRegistry */
+var ResponseFactory = require("../response-factory");
+var Q = require("q");
+//var Test = require("../test");
+
+function executionResponse(isFailed, executionTime, messageId, e) {
+  return ResponseFactory.getExecutionStatusResponseMessage (messageId, isFailed, executionTime, e);
+}
+
+var ExecuteHook = function(request, hookLevel, currentExecutionInfo) {
+  var deferred = Q.defer(),
+      timestamp = Date.now();
+
+  var hooks = hookRegistry.get(hookLevel);
+  for (var i = 0; i < hooks.length; i++) {
+    try {
+      hooks[i].apply({}, [currentExecutionInfo, hookLevel]);
+    } catch (e) {
+      deferred.reject(executionResponse(true, (Date.now() - timestamp), request.messageId, e));
+      return deferred.promise;
+    }
+  }
+
+  deferred.resolve(executionResponse(false, (Date.now() - timestamp), request.messageId));
+
+  return deferred.promise;
+};
+
+module.exports = ExecuteHook;

--- a/src/processor/ExecuteStepProcessor.js
+++ b/src/processor/ExecuteStepProcessor.js
@@ -16,14 +16,16 @@ var executeStep = function(request) {
     return item.value ? item.value : item.table;
   });
 
+  var timestamp = Date.now();
+
   new Test(stepRegistry.get(parsedStepText), parameters).run().then(
     function() {
-      var response = executionResponse(false, 0, request.messageId);
+      var response = executionResponse(false, (Date.now() - timestamp), request.messageId);
       deferred.resolve(response);
     },
 
     function() {
-      var errorResponse = executionResponse(true, 0, request.messageId);
+      var errorResponse = executionResponse(true, (Date.now() - timestamp), request.messageId);
       deferred.reject(errorResponse);
     }
   );

--- a/src/response-factory.js
+++ b/src/response-factory.js
@@ -39,7 +39,7 @@ exports.getStepValidateResponseMessage = function (messageId, isValid) {
 
 };
 
-exports.getExecutionStatusResponseMessage = function (messageId, isFailed, executionTime) {
+exports.getExecutionStatusResponseMessage = function (messageId, isFailed, executionTime, err) {
 
   return new Message({
     messageId: messageId,
@@ -47,7 +47,9 @@ exports.getExecutionStatusResponseMessage = function (messageId, isFailed, execu
     executionStatusResponse: {
       executionResult: {
         failed: isFailed,
-        executionTime: executionTime
+        executionTime: executionTime || 0,
+        stackTrace: err && err.stack ? err.stack : null,
+        errorMessage: err && err.message ? err.message : null
       }
     }
   });


### PR DESCRIPTION
Added 8 execution hooks with the help of @kashishm:

- `beforeSuite(fn, opts)`
- `beforeSpec(fn, opts)`
- `beforeScenario(fn, opts)`
- `beforeStep(fn, opts)`
- `afterSuite(fn, opts)`
- `afterSpec(fn, opts)`
- `afterScenario(fn, opts)`
- `afterStep(fn, opts)`

Tagged execution of hooks are supported. Tags need to be passed as the `opts` object. Here are the valid keys for the `opts` object:

```js
{
  "tags": [ "tag 1", "tag 2"],
  "operator": "AND" // valid values are "AND" and "OR". Defaults to "AND"
}
```

Fixes #4.